### PR TITLE
Detect a desktop using mousemove instead of mouseenter, fixes #7

### DIFF
--- a/src/jquery.bootstrap-dropdown-hover.js
+++ b/src/jquery.bootstrap-dropdown-hover.js
@@ -27,8 +27,8 @@
       _touchstartDetected = true;
     });
 
-    $('body').one('mouseenter.dropdownhover', function() {
-      // touchstart fires before mouseenter on touch devices
+    $('body').one('mousemove.dropdownhover', function() {
+      // touchstart fires before mousemove on touch devices
       if (!_touchstartDetected) {
         _mouseDetected = true;
       }


### PR DESCRIPTION
Newer Chrome browsers no longer fire mouseenter when the page is
refreshed or reached via a link, but only when the mouse actually leaves
and re-enters the page.
