### PR TITLE
Add support for data-target.

### DIFF
--- a/demo/index-bs3.html
+++ b/demo/index-bs3.html
@@ -515,8 +515,8 @@
       <div class="bs-example bs-example-4">
         <div class="dropdown">
           <div class="pretend_this_isnt_useless">
-            <a href="https://www.virtuosoft.eu/" data-click-behavior="link" class="btn btn-default dropdown-toggle" type="button" id="dropdownMenu4" data-toggle="dropdown" data-target=".bs-example-4 .dropdown-menu" aria-haspopup="true" aria-expanded="true">
-              Linked dropdown
+            <a href="https://www.virtuosoft.eu/" data-click-behavior="link" class="btn btn-default dropdown-toggle" type="button" id="dropdownMenu4" data-toggle="dropdown" data-target=".bs-example-4 .dropdown" aria-haspopup="true" aria-expanded="true">
+              Linked dropdown using target
               <span class="caret"></span>
             </a>
           </div>

--- a/demo/index-bs3.html
+++ b/demo/index-bs3.html
@@ -512,6 +512,24 @@
         </nav>
       </div>
 
+      <div class="bs-example bs-example-4">
+        <div class="dropdown">
+          <div class="pretend_this_isnt_useless">
+            <a href="https://www.virtuosoft.eu/" data-click-behavior="link" class="btn btn-default dropdown-toggle" type="button" id="dropdownMenu4" data-toggle="dropdown" data-target=".bs-example-4 .dropdown-menu" aria-haspopup="true" aria-expanded="true">
+              Linked dropdown
+              <span class="caret"></span>
+            </a>
+          </div>
+          <ul class="dropdown-menu" aria-labelledby="dropdownMenu4">
+            <li><a href="#">Action</a></li>
+            <li><a href="#">Another action</a></li>
+            <li><a href="#">Something else here</a></li>
+            <li role="separator" class="divider"></li>
+            <li><a href="#">Separated link</a></li>
+          </ul>
+        </div>
+      </div>
+
     </div>
 
     <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>

--- a/dist/jquery.bootstrap-dropdown-hover.js
+++ b/dist/jquery.bootstrap-dropdown-hover.js
@@ -64,7 +64,12 @@
       }
     });
 
-    $('.dropdown-toggle, .dropdown-menu', dropdown.element.parent()).on('mouseenter.dropdownhover', function () {
+    var $dep = dropdown.element.parent();
+    var dept = dropdown.element.data('target');
+    if(debt) {
+      $dep = $dep.add(debt);
+    }
+    $('.dropdown-toggle, .dropdown-menu', $dep).on('mouseenter.dropdownhover', function () {
       // seems to be a touch device
       if(_mouseDetected && !$(this.hover)) {
         _mouseDetected = false;
@@ -81,7 +86,7 @@
       }
     });
 
-    $('.dropdown-toggle, .dropdown-menu', dropdown.element.parent()).on('mouseleave.dropdownhover', function () {
+    $('.dropdown-toggle, .dropdown-menu', $dep).on('mouseleave.dropdownhover', function () {
       if (!_mouseDetected) {
         return;
       }
@@ -128,9 +133,14 @@
   }
 
   function removeEvents(dropdown) {
-    $('.dropdown-toggle, .dropdown-menu', dropdown.element.parent()).off('.dropdownhover');
+    var $dep = dropdown.element.parent();
+    var dept = dropdown.element.data('target');
+    if(debt) {
+      $dep = $dep.add(debt);
+    }
+    $('.dropdown-toggle, .dropdown-menu', $dep).off('.dropdownhover');
     // seems that bootstrap binds the click handler twice after we reinitializing the plugin after a destroy...
-    $('.dropdown-toggle, .dropdown-menu', dropdown.element.parent()).off('.dropdown');
+    $('.dropdown-toggle, .dropdown-menu', $dep).off('.dropdown');
     dropdown.element.off('.dropdownhover');
     $('body').off('.dropdownhover');
   }

--- a/src/jquery.bootstrap-dropdown-hover.js
+++ b/src/jquery.bootstrap-dropdown-hover.js
@@ -42,6 +42,22 @@
     this.init();
   }
 
+  function getParent($this) {
+    var selector = $this.attr('data-target')
+    , $parent
+
+    if (!selector) {
+      selector = $this.attr('href')
+      selector = selector && /#[A-Za-z]/.test(selector) && selector.replace(/.*(?=#[^\s]*$)/, '') //strip for ie7
+    }
+
+    $parent = selector && $(selector)
+
+    if (!$parent || !$parent.length) $parent = $this.parent()
+
+    return $parent
+  }
+
   function bindEvents(dropdown) {
     var $body = $('body');
 
@@ -56,7 +72,9 @@
       }
     });
 
-    $('.dropdown-toggle, .dropdown-menu', dropdown.element.parent()).on('mouseenter.dropdownhover', function () {
+    var $parent = getParent(dropdown.element);
+
+    $('.dropdown-toggle, .dropdown-menu', $parent).on('mouseenter.dropdownhover', function () {
       // seems to be a touch device
       if(_mouseDetected && !$(this.hover)) {
         _mouseDetected = false;
@@ -67,13 +85,13 @@
       }
 
       clearTimeout(_hideTimeoutHandler);
-      if (!dropdown.element.parent().is('.open, .show')) {
+      if (!$parent.is('.open, .show')) {
         _hardOpened = false;
         dropdown.element.dropdown('toggle');
       }
     });
 
-    $('.dropdown-toggle, .dropdown-menu', dropdown.element.parent()).on('mouseleave.dropdownhover', function () {
+    $('.dropdown-toggle, .dropdown-menu', $parent).on('mouseleave.dropdownhover', function () {
       if (!_mouseDetected) {
         return;
       }
@@ -82,7 +100,7 @@
         return;
       }
       _hideTimeoutHandler = setTimeout(function () {
-        if (dropdown.element.parent().is('.open, .show')) {
+        if ($parent.is('.open, .show')) {
           dropdown.element.dropdown('toggle');
         }
       }, dropdown.settings.hideTimeout);
@@ -109,7 +127,7 @@
           }
           else {
             _hardOpened = true;
-            if (dropdown.element.parent().is('.open, .show')) {
+            if ($parent.is('.open, .show')) {
               e.stopImmediatePropagation();
               e.preventDefault();
             }
@@ -120,9 +138,10 @@
   }
 
   function removeEvents(dropdown) {
-    $('.dropdown-toggle, .dropdown-menu', dropdown.element.parent()).off('.dropdownhover');
+    var $parent = getParent(dropdown.element);
+    $('.dropdown-toggle, .dropdown-menu', $parent).off('.dropdownhover');
     // seems that bootstrap binds the click handler twice after we reinitializing the plugin after a destroy...
-    $('.dropdown-toggle, .dropdown-menu', dropdown.element.parent()).off('.dropdown');
+    $('.dropdown-toggle, .dropdown-menu', $parent).off('.dropdown');
     dropdown.element.off('.dropdownhover');
     $('body').off('.dropdownhover');
   }

--- a/src/jquery.bootstrap-dropdown-hover.js
+++ b/src/jquery.bootstrap-dropdown-hover.js
@@ -43,19 +43,19 @@
   }
 
   function getParent($this) {
-    var selector = $this.attr('data-target')
-    , $parent
+    var selector = $this.attr('data-target');
+    var $parent;
 
     if (!selector) {
-      selector = $this.attr('href')
-      selector = selector && /#[A-Za-z]/.test(selector) && selector.replace(/.*(?=#[^\s]*$)/, '') //strip for ie7
+      selector = $this.attr('href');
+      selector = selector && /#[A-Za-z]/.test(selector) && selector.replace(/.*(?=#[^\s]*$)/, ''); //strip for ie7
     }
 
-    $parent = selector && $(selector)
+    $parent = selector && $(selector);
 
-    if (!$parent || !$parent.length) $parent = $this.parent()
+    if (!$parent || !$parent.length) {$parent = $this.parent();}
 
-    return $parent
+    return $parent;
   }
 
   function bindEvents(dropdown) {


### PR DESCRIPTION
Support explicit data-target attribute on dropdown, just as bootstrap itself does.

Originally complained about this on #19 but was misunderstood.

Note: This pull request only contain the change for the basic javascript file. Should be also done in the minified one but I don't know how (I hope it's not done manually).